### PR TITLE
Replace punctuations with spaces before matching keywords

### DIFF
--- a/src/main/java/seedu/address/logic/commands/deliverable/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/deliverable/ViewCommand.java
@@ -18,7 +18,7 @@ public class ViewCommand extends Command {
     public static final String COMMAND_WORD = "view";
     public static final String MESSAGE_VIEW_DELIVERABLE_SUCCESS = "Displayed deliverable: %1$s";
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Views the details of the deliverable identified by the index number used in "
+            + ": Displays the details of the deliverable identified by the index number used in "
             + "the displayed deliverable list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";

--- a/src/main/java/seedu/address/logic/commands/meeting/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meeting/ViewCommand.java
@@ -18,9 +18,9 @@ public class ViewCommand extends Command {
     public static final String COMMAND_WORD = "view";
     public static final String MESSAGE_VIEW_MEETING_SUCCESS = "Displayed meeting: %1$s";
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Displays the details of the meeting identified by the index number used in the displayed meeting list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+        + ": Displays the details of the meeting identified by the index number used in the displayed meeting list.\n"
+        + "Parameters: INDEX (must be a positive integer)\n"
+        + "Example: " + COMMAND_WORD + " 1";
 
     private final Index targetIndex;
 

--- a/src/main/java/seedu/address/logic/commands/meeting/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meeting/ViewCommand.java
@@ -18,7 +18,7 @@ public class ViewCommand extends Command {
     public static final String COMMAND_WORD = "view";
     public static final String MESSAGE_VIEW_MEETING_SUCCESS = "Displayed meeting: %1$s";
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Views the details of the meeting identified by the index number used in the displayed meeting list.\n"
+            + ": Displays the details of the meeting identified by the index number used in the displayed meeting list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 

--- a/src/main/java/seedu/address/logic/commands/person/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/person/ViewCommand.java
@@ -18,9 +18,9 @@ public class ViewCommand extends Command {
     public static final String COMMAND_WORD = "view";
     public static final String MESSAGE_VIEW_PERSON_SUCCESS = "Displayed contact: %1$s";
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Displays the details of the contact identified by the index number used in the displayed contact list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+        + ": Displays the details of the contact identified by the index number used in the displayed contact list.\n"
+        + "Parameters: INDEX (must be a positive integer)\n"
+        + "Example: " + COMMAND_WORD + " 1";
 
     private final Index targetIndex;
 

--- a/src/main/java/seedu/address/logic/commands/person/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/person/ViewCommand.java
@@ -18,7 +18,7 @@ public class ViewCommand extends Command {
     public static final String COMMAND_WORD = "view";
     public static final String MESSAGE_VIEW_PERSON_SUCCESS = "Displayed contact: %1$s";
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Views the details of the contact identified by the index number used in the displayed contact list.\n"
+            + ": Displays the details of the contact identified by the index number used in the displayed contact list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 

--- a/src/main/java/seedu/address/logic/parser/deliverable/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/deliverable/FindCommandParser.java
@@ -25,7 +25,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        String[] nameKeywords = trimmedArgs.replaceAll("\\W", " ").split("\\s+");
 
         return new FindCommand(new TitleDescriptionContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
     }

--- a/src/main/java/seedu/address/logic/parser/meeting/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/meeting/FindCommandParser.java
@@ -24,7 +24,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        String[] nameKeywords = trimmedArgs.replaceAll("\\W", " ").split("\\s+");
 
         return new FindCommand(new TitleDescriptionContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
     }

--- a/src/main/java/seedu/address/logic/parser/person/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/person/FindCommandParser.java
@@ -26,7 +26,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        String[] nameKeywords = trimmedArgs.replaceAll("\\W", " ").split("\\s+");
 
         return new FindCommand(new NameDescriptionContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
     }

--- a/src/main/java/seedu/address/model/deliverable/deliverable/TitleDescriptionContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/deliverable/deliverable/TitleDescriptionContainsKeywordsPredicate.java
@@ -15,8 +15,10 @@ public class TitleDescriptionContainsKeywordsPredicate implements Predicate<Deli
     @Override
     public boolean test(Deliverable deliverable) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(deliverable.getTitle().value, keyword)
-                        || StringUtil.containsWordIgnoreCase(deliverable.getDescription().value.orElse(""), keyword));
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(
+                        deliverable.getTitle().value.replaceAll("\\W", " "), keyword)
+                        || StringUtil.containsWordIgnoreCase(
+                                deliverable.getDescription().value.orElse("").replaceAll("\\W", " "), keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/meeting/meeting/TitleDescriptionContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/meeting/meeting/TitleDescriptionContainsKeywordsPredicate.java
@@ -18,8 +18,10 @@ public class TitleDescriptionContainsKeywordsPredicate implements Predicate<Meet
     @Override
     public boolean test(Meeting meeting) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(meeting.getTitle().value, keyword)
-                        || StringUtil.containsWordIgnoreCase(meeting.getDescription().value.orElse(""), keyword));
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(
+                        meeting.getTitle().value.replaceAll("\\W", " "), keyword)
+                        || StringUtil.containsWordIgnoreCase(
+                                meeting.getDescription().value.orElse("").replaceAll("\\W", " "), keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/person/NameDescriptionContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/person/NameDescriptionContainsKeywordsPredicate.java
@@ -18,8 +18,10 @@ public class NameDescriptionContainsKeywordsPredicate implements Predicate<Perso
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword)
-                        || StringUtil.containsWordIgnoreCase(person.getDescription().value.orElse(""), keyword));
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(
+                        person.getName().fullName.replaceAll("\\W", " "), keyword)
+                        || StringUtil.containsWordIgnoreCase(
+                                person.getDescription().value.orElse("").replaceAll("\\W", " "), keyword));
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/LogicPersonManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicPersonManagerTest.java
@@ -40,7 +40,6 @@ public class LogicPersonManagerTest {
 
     private ModelPerson modelPerson = new ModelPersonManager();
     private LogicPerson logic;
-    private Object CommandException;
 
     @BeforeEach
     public void setUp() {


### PR DESCRIPTION
Fixes #249 

Note: `find mock-up` will match `mock practice`, `come up here`, `create mock up`, `create another mock-up`, `go up and mock him`, `this --mock?`, `Stay up.` but cannot match `mockup` (and kinda vice versa)